### PR TITLE
arreglo bug para no tener que refrescar la pagina

### DIFF
--- a/client/js/income.js
+++ b/client/js/income.js
@@ -75,6 +75,7 @@ window.onRemove = async function () {
     await movementService.remove(movement);
     state.movement = {};
     render('movement-form.html', state, refs.form);
+    window.location.reload();
 };
 
 /**
@@ -93,6 +94,7 @@ window.onSave = async function (e) {
 
     state.movement = {};
     render('movement-form.html', state, refs.form);
+    window.location.reload();
 };
 
 init();


### PR DESCRIPTION
Resuelvo bug 5.
              5. Al crear un movimiento, hay que hacer refresh para que aparezca reflejado
              en la lista. Arreglar esto haciendo que el cambio impacte inmediatamente en
              la lista.